### PR TITLE
Support 3.0.4

### DIFF
--- a/gemfiles/rspec3.gemfile
+++ b/gemfiles/rspec3.gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
-gem 'rspec', "~> 3.0.0"
+gem 'rspec'             , "~> 3.0.0"
+gem 'rspec-core'        , "~> 3.0.4"
+gem 'rspec-expectations', "~> 3.0.4"
+gem 'rspec-mocks'       , "~> 3.0.4"
 
 gemspec path: '../'

--- a/lib/rspec/temp_dir/uses_temp_dir.rb
+++ b/lib/rspec/temp_dir/uses_temp_dir.rb
@@ -1,6 +1,7 @@
 require "tmpdir"
+require "rspec"
 
-shared_context "uses temp dir" do
+(RSpec.respond_to?(:shared_context) ? RSpec : Object).shared_context "uses temp dir" do
   around do |example|
     Dir.mktmpdir("rspec-") do |dir|
       @temp_dir = dir


### PR DESCRIPTION
```
[sue445@sue445-MBP.local] ✓ ~/workspace/padrino/gemoire (master)
[sue445@sue445-MBP.local] [08-20 20:57:45] $ RACK_ENV=test bundle exec rake ar:migrate
rake aborted!
NoMethodError: undefined method `shared_context' for main:Object
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/rspec-temp_dir-0.0.1/lib/rspec/temp_dir/uses_temp_dir.rb:3:in `<top (required)>'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/rspec-temp_dir-0.0.1/lib/rspec/temp_dir.rb:2:in `require'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/rspec-temp_dir-0.0.1/lib/rspec/temp_dir.rb:2:in `<top (required)>'
/Users/sue445/dev/workspace/padrino/gemoire/config/boot.rb:8:in `<top (required)>'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/padrino-core-0.12.3/lib/padrino-core/cli/rake_tasks.rb:12:in `require'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/padrino-core-0.12.3/lib/padrino-core/cli/rake_tasks.rb:12:in `block in <top (required)>'
LoadError: cannot load such file -- rspec-temp_dir
/Users/sue445/dev/workspace/padrino/gemoire/config/boot.rb:8:in `<top (required)>'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/padrino-core-0.12.3/lib/padrino-core/cli/rake_tasks.rb:12:in `require'
/Users/sue445/dev/workspace/padrino/gemoire/vendor/bundle/ruby/2.1.0/gems/padrino-core-0.12.3/lib/padrino-core/cli/rake_tasks.rb:12:in `block in <top (required)>'
Tasks: TOP => ar:migrate => environment
(See full trace by running task with --trace)
```
