### PR TITLE
Fix no method error for Pathname

### DIFF
--- a/lib/rspec/temp_dir/uses_temp_dir.rb
+++ b/lib/rspec/temp_dir/uses_temp_dir.rb
@@ -1,5 +1,6 @@
 require "tmpdir"
 require "rspec"
+require 'pathname'
 
 (RSpec.respond_to?(:shared_context) ? RSpec : Object).shared_context "uses temp dir" do
   around do |example|


### PR DESCRIPTION
Error occurs in ruby 2.2.2.
**Pathname** was a problem that can not be resolved.
I added a **pathname module**.

	Failure/Error: subject{ temp_dir_path }
	     NoMethodError:
	       undefined method `Pathname' for #<RSpec::ExampleGroups::UsesTempDir::TempDirPath:0x007fdf88a7a2a0>
	     # ./lib/rspec/temp_dir/uses_temp_dir.rb:15:in `temp_dir_path'
	     # ./spec/rspec/uses_temp_dir_spec.rb:19:in `block (3 levels) in <top (required)>'
	     # ./spec/rspec/uses_temp_dir_spec.rb:22:in `block (3 levels) in <top (required)>'
	     # ./lib/rspec/temp_dir/uses_temp_dir.rb:8:in `block (3 levels) in <top (required)>'
	     # ./lib/rspec/temp_dir/uses_temp_dir.rb:6:in `block (2 levels) in <top (required)>'

I tried ruby version by 2.2.X. 

	holyshared:rspec-temp_dir shared-hat$ ruby --version
	ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]
