### PR TITLE
admit test failure on rspec 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ notifications:
 matrix:
   allow_failures:
   - rvm: ruby-head
+  - gemfile: gemfiles/rspec2.gemfile


### PR DESCRIPTION
Because rspec 2.x is already retired